### PR TITLE
Fix wrong check for target platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const isEnvTrue = value => {
 };
 
 module.exports = async params => {
-	if (params.platform !== 'darwin') {
+	if (params.electronPlatformName !== 'darwin') {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const isEnvTrue = value => {
 };
 
 module.exports = async params => {
-	if (process.platform !== 'darwin') {
+	if (params.platform !== 'darwin') {
 		return;
 	}
 


### PR DESCRIPTION
As of right now, this module is not compatible with Linux and Windows. This is caused by a small mistake in the platform check. You should check for `params.electronPlatformName` instead of `process.platform`.

Tested it for macOS, Linux and Windows; especially when building a "combined" builds (e.g. `-mwl`).

The following exception will be thrown with the current version:
```
Notarizing com.[...] found at /[...]/Foobar.app
  ⨯ Failed to zip application, exited with code: 12

	zip warning: name not matched: Foobar.app

zip error: Nothing to do! (try: zip -r -y /var/folders/l7/t8_bx7q56514y3jvn1w_5sjc0000gn/T/electron-notarize-BOOg8u/Foobar.zip . -i Foobar.app)
  stackTrace=
Error: Failed to zip application, exited with code: 12
zip warning: name not matched: Foobar.app
zip error: Nothing to do! (try: zip -r -y /var/folders/l7/t8_bx7q56514y3jvn1w_5sjc0000gn/T/electron-notarize-BOOg8u/Foobar.zip . -i Foobar.app)
```

This is the output of electron-builder `v21.2.0`:
```
{
  appOutDir: '/Users/[...]/dist/mac',
  outDir: '/Users/[...]/dist',
  arch: 1,
  targets: [
    DmgTarget {
      name: 'dmg',
      [...]
    },
    ArchiveTarget {
      name: 'zip',
      [...]
    }
  ],
  packager: MacPackager {
    platform: Platform {
      name: 'mac',
      buildConfigurationKey: 'mac',
      nodeName: 'darwin'
    },
  },
  electronPlatformName: 'darwin'
}
```