### PR TITLE
Log error from notarytool exception

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -44,7 +44,9 @@ module.exports = async () => {
 				...creds,
 				tool: 'notarytool'
 			};
-		} catch {}
+		} catch (err) {
+			console.error('notarytool attempted but failed, trying legacy. error: ', err);
+		}
 	} else {
 		console.log('notarytool not found, trying legacy.');
 	}


### PR DESCRIPTION
My org has been using `electron-builder-notarize` for some time to do our notarization (thanks for the tool!) Apple recently emailed my org their notice about `altool` being deprecated for notarization in favor of `notarytool`, so this led me to start looking closer at which tool was actually being invoked in our CI. I confirmed from looking at respective notarization history logs that it was indeed `altool`, but I was slowed down in figuring out the root cause because this empty `catch` caused a silent fallback to `altool`. Printing out the exception like I'm proposing in this PR would have helped. Here's an example of how it looks in my GitHub Actions CI doing its thing.

```
notarytool attempted but failed, trying legacy. error:  Error: The teamId property is required when using notarization with password credentials
    at validateNotaryToolAuthorizationArgs (/Users/runner/work/zui-insiders/zui-insiders/node_modules/electron-notarize/src/validate-args.ts:111:13)
    at module.exports (/Users/runner/work/zui-insiders/zui-insiders/node_modules/electron-builder-notarize/validate.js:42:18)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at module.exports (/Users/runner/work/zui-insiders/zui-insiders/node_modules/electron-builder-notarize/index.js:64:14)
    at MacPackager.doSignAfterPack (/Users/runner/work/zui-insiders/zui-insiders/node_modules/app-builder-lib/src/platformPackager.ts:332:7)
    at MacPackager.doPack (/Users/runner/work/zui-insiders/zui-insiders/node_modules/app-builder-lib/src/platformPackager.ts:314:7)
    at MacPackager.pack (/Users/runner/work/zui-insiders/zui-insiders/node_modules/app-builder-lib/src/macPackager.ts:1[92](https://github.com/brimdata/zui-insiders/actions/runs/5282473257/jobs/9557432659#step:9:95):7)
    at Packager.doBuild (/Users/runner/work/zui-insiders/zui-insiders/node_modules/app-builder-lib/src/packager.ts:441:9)
    at Object.executeFinally (/Users/runner/work/zui-insiders/zui-insiders/node_modules/builder-util/src/promise.ts:12:14)
    at Packager._build (/Users/runner/work/zui-insiders/zui-insiders/node_modules/app-builder-lib/src/packager.ts:376:31)
    at Packager.build (/Users/runner/work/zui-insiders/zui-insiders/node_modules/app-builder-lib/src/packager.ts:337:12)
    at Object.executeFinally (/Users/runner/work/zui-insiders/zui-insiders/node_modules/builder-util/src/promise.ts:12:14)
📦 Start notarizing io.brimdata.zui-insiders found at /Users/runner/work/zui-insiders/zui-insiders/installers/mac/Zui - Insiders.app
🌟 Notarizing io.brimdata.zui-insiders successfully !
```